### PR TITLE
fix rename modal: stay previous name

### DIFF
--- a/RN/components/Button/Button.tsx
+++ b/RN/components/Button/Button.tsx
@@ -16,7 +16,7 @@ type ButtonProps = {
   onPress?: () => void;
 };
 
-type ButtonState = "default" | "loading";
+type ButtonState = "default" | "loading" | "disabled";
 
 export default function Button({
   title,
@@ -80,9 +80,14 @@ function PrimaryButton({ title, onPress, state, style }: ButtonProps) {
       </View>
     );
   }
+  const isDisabled = state === "disabled";
 
   return (
-    <TouchableOpacity onPress={onPress} style={[styles.container, style]}>
+    <TouchableOpacity
+      onPress={onPress}
+      style={[styles.container, isDisabled && styles.disabled, style]}
+      disabled={isDisabled}
+    >
       <ThemedText type="defaultSemiBold" colorType="primaryButtonText">
         {title}
       </ThemedText>
@@ -106,5 +111,8 @@ const styles = StyleSheet.create({
   linkContainer: {
     padding: 12,
     alignItems: "center",
+  },
+  disabled: {
+    backgroundColor: "#d4d4d4",
   },
 });

--- a/RN/components/Modal/RenameModal.tsx
+++ b/RN/components/Modal/RenameModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { View } from "react-native";
 import Button from "@/components/Button/Button";
 import { BaseModal, BaseModalProps } from "@/components/Modal/BaseModal";
@@ -14,19 +14,20 @@ export interface RenameModalProps
 }
 
 export function RenameModal({
-  id: _id,
-  name: _name,
+  id,
+  name,
   isVisible,
   onRenamed,
   onClose,
 }: RenameModalProps) {
-  const [id, setId] = useState(_id);
-  const [name, setName] = useState(_name);
+  const [text, setText] = useState(name);
   const [errorMessages, setErrorMessages] = useState("");
 
+  useEffect(() => {
+    setText(name);
+  }, [name]);
+
   function reset() {
-    setId(_id);
-    setName(_name);
     setErrorMessages("");
   }
 
@@ -53,7 +54,7 @@ export function RenameModal({
     if (isValidated) {
       renameQRCode({
         id,
-        name,
+        name: text,
       });
 
       reset();
@@ -67,10 +68,10 @@ export function RenameModal({
       <View>
         <TextInput
           label="Name"
-          value={name}
+          value={text}
           errorMessage={errorMessages}
           placeholder="Instagram"
-          onChangeText={setName}
+          onChangeText={setText}
         />
 
         <HorizontalSpacer height={32} />
@@ -78,7 +79,7 @@ export function RenameModal({
         <Button
           title="Save"
           buttonType="primary"
-          state="default"
+          state={text.length <= 0 ? "disabled" : "default"}
           onPress={handleSave}
         />
 


### PR DESCRIPTION
# What

- When try to rename, rename modal will open and show textinput but name didn't clean up. So it will show previous textInput.
- Add button disabled. and validation empty string.
![CleanShot 2024-09-16 at 20 48 20](https://github.com/user-attachments/assets/7df67d31-61e2-44bd-88d4-6a9c8f913824)
